### PR TITLE
Issue #2: Renamed the resource directory for the MedSavantClient module.

### DIFF
--- a/MedSavantClient/pom.xml
+++ b/MedSavantClient/pom.xml
@@ -168,11 +168,6 @@
   </repositories>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Changed from resources to src/main/resources.

Originally, the contents of the resource folder was not copied to the target jar.
